### PR TITLE
added auto advance settings state and slider

### DIFF
--- a/src/components/AppSettings/index.tsx
+++ b/src/components/AppSettings/index.tsx
@@ -17,7 +17,6 @@ const AppSettings = ({ darkMode, setDarkMode }: AppSettingsProps) => {
     setShowSettings,
     autoAdvanceWords,
     setAutoAdvanceWords,
-    autoAdvanceWordsInterval,
     setAutoAdvanceWordsInterval,
     autoPlayAudio,
     setAutoPlayAudio,
@@ -28,6 +27,11 @@ const AppSettings = ({ darkMode, setDarkMode }: AppSettingsProps) => {
   const hideSettings = () => {
     setShowSettings(false);
   };
+
+  // @ts-ignore event not needed
+  const handleSlideChange = (event: React.ChangeEvent<{}>, value: number | number[]) => {
+    setAutoAdvanceWordsInterval(value as number)
+  }
 
   return (
     <>
@@ -74,7 +78,7 @@ const AppSettings = ({ darkMode, setDarkMode }: AppSettingsProps) => {
               <Slider 
                 disabled={!autoAdvanceWords} 
                 defaultValue={5}
-                onChange={(e, value) => setAutoAdvanceWordsInterval(value as number)}
+                onChange={handleSlideChange}
                 marks
                 min={1}
                 max={15}

--- a/src/components/AppSettings/index.tsx
+++ b/src/components/AppSettings/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Backdrop } from '@material-ui/core';
 import { useSettings } from 'hooks/useSettings';
 import Switch from '@material-ui/core/Switch';
+import Slider from '@material-ui/core/Slider';
 import CloseIcon from '@material-ui/icons/Close';
 import * as s from './styles';
 
@@ -16,6 +17,8 @@ const AppSettings = ({ darkMode, setDarkMode }: AppSettingsProps) => {
     setShowSettings,
     autoAdvanceWords,
     setAutoAdvanceWords,
+    autoAdvanceWordsInterval,
+    setAutoAdvanceWordsInterval,
     autoPlayAudio,
     setAutoPlayAudio,
     maleVoice,
@@ -68,6 +71,7 @@ const AppSettings = ({ darkMode, setDarkMode }: AppSettingsProps) => {
                 className="setting-switch"
               />
               <span>Auto advances</span>
+              <Slider disabled={autoAdvanceWords} defaultValue={30} aria-label="Disabled slider" />
             </div>
             <div>
               <Switch

--- a/src/components/AppSettings/index.tsx
+++ b/src/components/AppSettings/index.tsx
@@ -71,7 +71,15 @@ const AppSettings = ({ darkMode, setDarkMode }: AppSettingsProps) => {
                 className="setting-switch"
               />
               <span>Auto advances</span>
-              <Slider disabled={autoAdvanceWords} defaultValue={30} aria-label="Disabled slider" />
+              <Slider 
+                disabled={autoAdvanceWords} 
+                defaultValue={5}
+                marks
+                min={1}
+                max={15}
+                valueLabelDisplay="auto"
+                aria-label="Auto Advance Interval in seconds" step={1}
+              />
             </div>
             <div>
               <Switch

--- a/src/components/AppSettings/index.tsx
+++ b/src/components/AppSettings/index.tsx
@@ -72,8 +72,9 @@ const AppSettings = ({ darkMode, setDarkMode }: AppSettingsProps) => {
               />
               <span>Auto advances</span>
               <Slider 
-                disabled={autoAdvanceWords} 
+                disabled={!autoAdvanceWords} 
                 defaultValue={5}
+                onChange={(e, value) => setAutoAdvanceWordsInterval(value as number)}
                 marks
                 min={1}
                 max={15}

--- a/src/hooks/useSettings/index.tsx
+++ b/src/hooks/useSettings/index.tsx
@@ -18,7 +18,7 @@ const SettingsContextDefaultValues = {
   setShowSettings: () => null,
   autoAdvanceWords: false,
   setAutoAdvanceWords: () => null,
-  autoAdvanceWordsInterval: 1000,
+  autoAdvanceWordsInterval: 5000,
   setAutoAdvanceWordsInterval: () => null,
   autoPlayAudio: false,
   setAutoPlayAudio: () => null,

--- a/src/hooks/useSettings/index.tsx
+++ b/src/hooks/useSettings/index.tsx
@@ -18,7 +18,7 @@ const SettingsContextDefaultValues = {
   setShowSettings: () => null,
   autoAdvanceWords: false,
   setAutoAdvanceWords: () => null,
-  autoAdvanceWordsInterval: 5000,
+  autoAdvanceWordsInterval: 5,
   setAutoAdvanceWordsInterval: () => null,
   autoPlayAudio: false,
   setAutoPlayAudio: () => null,
@@ -37,7 +37,7 @@ export type SettingsProviderProps = {
 export const SettingsProvider = ({ children }: SettingsProviderProps) => {
   const [showSettings, setShowSettings] = useState<boolean>(false);
   const [autoAdvanceWords, setAutoAdvanceWords] = useState<boolean>(false);
-  const [autoAdvanceWordsInterval, setAutoAdvanceWordsInterval] = useState<number>(1000);
+  const [autoAdvanceWordsInterval, setAutoAdvanceWordsInterval] = useState<number>(5);
   const [autoPlayAudio, setAutoPlayAudio] = useState<boolean>(false);
   const [maleVoice, setMaleVoice] = useState<boolean>(false);
 

--- a/src/hooks/useSettings/index.tsx
+++ b/src/hooks/useSettings/index.tsx
@@ -5,6 +5,8 @@ type SettingsContextData = {
   setShowSettings: (value: boolean) => void;
   autoAdvanceWords: boolean;
   setAutoAdvanceWords: (value: boolean) => void;
+  autoAdvanceWordsInterval: number;
+  setAutoAdvanceWordsInterval: (value: number) => void;
   autoPlayAudio: boolean;
   setAutoPlayAudio: (value: boolean) => void;
   maleVoice: boolean;
@@ -16,6 +18,8 @@ const SettingsContextDefaultValues = {
   setShowSettings: () => null,
   autoAdvanceWords: false,
   setAutoAdvanceWords: () => null,
+  autoAdvanceWordsInterval: 1000,
+  setAutoAdvanceWordsInterval: () => null,
   autoPlayAudio: false,
   setAutoPlayAudio: () => null,
   maleVoice: false,
@@ -33,6 +37,7 @@ export type SettingsProviderProps = {
 export const SettingsProvider = ({ children }: SettingsProviderProps) => {
   const [showSettings, setShowSettings] = useState<boolean>(false);
   const [autoAdvanceWords, setAutoAdvanceWords] = useState<boolean>(false);
+  const [autoAdvanceWordsInterval, setAutoAdvanceWordsInterval] = useState<number>(1000);
   const [autoPlayAudio, setAutoPlayAudio] = useState<boolean>(false);
   const [maleVoice, setMaleVoice] = useState<boolean>(false);
 
@@ -43,6 +48,8 @@ export const SettingsProvider = ({ children }: SettingsProviderProps) => {
         setShowSettings,
         autoAdvanceWords,
         setAutoAdvanceWords,
+        autoAdvanceWordsInterval,
+        setAutoAdvanceWordsInterval,
         autoPlayAudio,
         setAutoPlayAudio,
         maleVoice,

--- a/src/templates/Word/index.tsx
+++ b/src/templates/Word/index.tsx
@@ -44,7 +44,7 @@ const WordPageTemplate = ({ word }: WordPageTemplateProps) => {
     if (autoAdvanceWords && !autoPlayAudio) {
       advanceTimeout = setTimeout(() => {
         loadAnotherWord();
-      }, autoAdvanceWordsInterval);
+      }, autoAdvanceWordsInterval * 1000);
     } else {
       clearTimeout(advanceTimeout);
     }

--- a/src/templates/Word/index.tsx
+++ b/src/templates/Word/index.tsx
@@ -17,7 +17,7 @@ const WordPageTemplate = ({ word }: WordPageTemplateProps) => {
   const [animateIcon, setAnimateIcon] = useState(false);
   const [showMeaning, setShowMeaning] = useState(false);
   const [nextWord, setNextWord] = useState<string>('');
-  const { autoAdvanceWords, autoPlayAudio, maleVoice } = useSettings();
+  const { autoAdvanceWords, autoAdvanceWordsInterval, autoPlayAudio, maleVoice } = useSettings();
 
   const phraseRef = useRef<HTMLSpanElement>(null);
 
@@ -44,7 +44,9 @@ const WordPageTemplate = ({ word }: WordPageTemplateProps) => {
     if (autoAdvanceWords && !autoPlayAudio) {
       advanceTimeout = setTimeout(() => {
         loadAnotherWord();
-      }, 5000);
+      }, autoAdvanceWordsInterval);
+    } else {
+      clearTimeout(advanceTimeout);
     }
 
     return () => {


### PR DESCRIPTION
# Description

This PR adds the slider to the settings modal. Additional it adds the state to the SettingsContext to be used in the App for controlling the speed of change to jump to the next word.

Fixes #3 

## Type of change

Please delete options that are not relevant.

- [ ] Correction on an existing word
- [ ] New word (translation, image, phrase)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (non-breaking change that updates the documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

By running the application enabling / disabling auto advance and changing the interval back and forth.

## Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/sbplat/Macro-API/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/sbplat/Macro-API/blob/main/CODE_OF_CONDUCT.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Consider giving a ⭐ if you enjoy the project
