### PR TITLE
Fixed typo in settings

### DIFF
--- a/src/components/AppSettings/index.tsx
+++ b/src/components/AppSettings/index.tsx
@@ -77,7 +77,7 @@ const AppSettings = ({ darkMode, setDarkMode }: AppSettingsProps) => {
                 inputProps={{ 'aria-label': 'Male voice' }}
                 className="setting-switch"
               />
-              <span>Male voice</span>
+              <span>Female voice</span>
             </div>
           </s.Settings>
         </s.SettingsContainer>


### PR DESCRIPTION
# Description

There's a error in Settings where on turning on Male Voice , female voice plays. So, I changed the name to Female Voice, now things make sense there.

![image](https://user-images.githubusercontent.com/74503582/198582225-5c72dba4-3cbc-44fb-a9d4-a09b8d729d0d.png)


Fixes #15 
